### PR TITLE
UX: Remove heading tags from last seen stat

### DIFF
--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -1,5 +1,5 @@
 <script type="text/x-handlebars" data-template-name="/connectors/user-card-metadata/last-seen-metadata">
     {{#if user.last_seen_at}}
-        <h3><span class='desc'>{{i18n 'user.last_seen'}}</span> {{format-date user.last_seen_at leaveAgo="true"}}</h3>
+        <span class='desc'>{{i18n 'user.last_seen'}}</span> {{format-date user.last_seen_at leaveAgo="true"}}
     {{/if}}
 </script>


### PR DESCRIPTION
We removed heading tags from the user card in core, because they're not technically supposed to be used like this